### PR TITLE
 Fix parser tests for whitespace sensitivity (#8)

### DIFF
--- a/crates/helios-parser/src/grammar.rs
+++ b/crates/helios-parser/src/grammar.rs
@@ -21,30 +21,30 @@ where
     m.complete(p, SyntaxKind::Root)
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use crate::check;
-//     use expect_test::expect;
-//
-//     #[test]
-//     fn test_parse_multiple_declarations() {
-//         check(
-//             "let a = 1\na",
-//             expect![[r#"
-//                 Root@0..11
-//                   Dec_GlobalBinding@0..10
-//                     Kwd_Let@0..3 "let"
-//                     Whitespace@3..4 " "
-//                     Identifier@4..5 "a"
-//                     Whitespace@5..6 " "
-//                     Sym_Eq@6..7 "="
-//                     Whitespace@7..8 " "
-//                     Exp_Literal@8..10
-//                       Lit_Integer@8..9 "1"
-//                       Newline@9..10 "\n"
-//                   Exp_VariableRef@10..11
-//                     Identifier@10..11 "a"
-//             "#]],
-//         );
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use crate::check;
+    use expect_test::expect;
+
+    #[test]
+    fn test_parse_multiple_declarations() {
+        check(
+            "let a = 1\na",
+            expect![[r#"
+                Root@0..11
+                  Dec_GlobalBinding@0..10
+                    Kwd_Let@0..3 "let"
+                    Whitespace@3..4 " "
+                    Identifier@4..5 "a"
+                    Whitespace@5..6 " "
+                    Sym_Eq@6..7 "="
+                    Whitespace@7..8 " "
+                    Exp_Literal@8..10
+                      Lit_Integer@8..9 "1"
+                      Newline@9..10 "\n"
+                  Exp_VariableRef@10..11
+                    Identifier@10..11 "a"
+            "#]],
+        );
+    }
+}

--- a/crates/helios-parser/src/grammar/decl.rs
+++ b/crates/helios-parser/src/grammar/decl.rs
@@ -23,7 +23,9 @@ where
     p.expect(SyntaxKind::Sym_Eq, SyntaxKind::Dec_GlobalBinding);
 
     expr::expr(p, 0);
-    p.expect(SyntaxKind::Newline, SyntaxKind::Dec_GlobalBinding);
+    // Note: Newline is treated as trivia (skipped by the parser), so we don't
+    // explicitly expect it here. The Newline token will be attached as trailing
+    // trivia to the expression by the Sink.
 
     m.complete(p, SyntaxKind::Dec_GlobalBinding)
 }

--- a/crates/helios-parser/src/grammar/expr.rs
+++ b/crates/helios-parser/src/grammar/expr.rs
@@ -84,6 +84,7 @@ const LHS_KINDS: &[SyntaxKind] = &[
     SyntaxKind::Lit_String,
     SyntaxKind::Identifier,
     SyntaxKind::Sym_LParen,
+    SyntaxKind::Indent,
 ];
 
 /// Parses the left-hand side of an expression.
@@ -423,12 +424,32 @@ mod tests {
     }
 
     #[test]
-    fn test() {
-        let source = "
+    fn test_parse_indented_continuation() {
+        check(
+            "
 1 + 1 +
-    10";
-        let tree = crate::parse(0, source);
-        println!("{}", tree.debug_tree());
+    10",
+            expect![[r#"
+                Root@0..15
+                  Newline@0..1 "\n"
+                  Exp_Binary@1..15
+                    Exp_Binary@1..7
+                      Exp_Literal@1..3
+                        Lit_Integer@1..2 "1"
+                        Whitespace@2..3 " "
+                      Sym_Plus@3..4 "+"
+                      Whitespace@4..5 " "
+                      Exp_Literal@5..7
+                        Lit_Integer@5..6 "1"
+                        Whitespace@6..7 " "
+                    Sym_Plus@7..8 "+"
+                    Exp_Indented@8..15
+                      Indent@8..13 "\n    "
+                      Exp_Literal@13..15
+                        Lit_Integer@13..15 "10"
+                      Dedent@15..15 ""
+            "#]],
+        );
     }
 
     //     #[test]

--- a/crates/helios-parser/src/grammar/expr.rs
+++ b/crates/helios-parser/src/grammar/expr.rs
@@ -452,36 +452,39 @@ mod tests {
         );
     }
 
-    //     #[test]
-    //     fn test_parse_binary_expression_interspersed_with_comments() {
-    //         check(
-    //             "
-    // 1 +
-    //   1 + # Add one
-    //     10 # Add ten",
-    //             expect![[r##"
-    //                 Root@0..35
-    //                   Newline@0..1 "\n"
-    //                   Exp_Binary@1..35
-    //                     Exp_Binary@1..21
-    //                       Exp_Literal@1..5
-    //                         Lit_Integer@1..2 "1"
-    //                         Indent@2..5 "\n  "
-    //                       Sym_Plus@5..6 "+"
-    //                       Whitespace@6..7 " "
-    //                       Exp_Literal@7..21
-    //                         Lit_Integer@7..8 "1"
-    //                         Whitespace@8..9 " "
-    //                         Comment@9..18 "# Add one"
-    //                         Newline@18..21 "\n  "
-    //                     Sym_Plus@21..22 "+"
-    //                     Whitespace@22..23 " "
-    //                     Exp_Literal@23..35
-    //                       Lit_Integer@23..25 "10"
-    //                       Whitespace@25..26 " "
-    //                       Comment@26..35 "# Add ten"
-    //                       Dedent@35..35 ""
-    //             "##]],
-    //         );
-    //     }
+    #[test]
+    fn test_parse_binary_expression_interspersed_with_comments() {
+        check(
+            "
+1 +
+  1 + # Add one
+    10 # Add ten",
+            expect![[r##"
+                Root@0..37
+                  Newline@0..1 "\n"
+                  Exp_Binary@1..37
+                    Exp_Literal@1..3
+                      Lit_Integer@1..2 "1"
+                      Whitespace@2..3 " "
+                    Sym_Plus@3..4 "+"
+                    Exp_Indented@4..37
+                      Indent@4..7 "\n  "
+                      Exp_Binary@7..37
+                        Exp_Literal@7..9
+                          Lit_Integer@7..8 "1"
+                          Whitespace@8..9 " "
+                        Sym_Plus@9..10 "+"
+                        Whitespace@10..11 " "
+                        Comment@11..20 "# Add one"
+                        Exp_Indented@20..37
+                          Indent@20..25 "\n    "
+                          Exp_Literal@25..37
+                            Lit_Integer@25..27 "10"
+                            Whitespace@27..28 " "
+                            Comment@28..37 "# Add ten"
+                          Dedent@37..37 ""
+                      Dedent@37..37 ""
+            "##]],
+        );
+    }
 }


### PR DESCRIPTION
## Summary
  - Fix Indent token handling by adding it to LHS_KINDS
  - Remove erroneous Newline expectation from global_binding (Newline is trivia)
  - Enable 3 previously commented-out/broken tests

  ## Changes
  - `expr.rs`: Add `SyntaxKind::Indent` to `LHS_KINDS`, fix `test_parse_indented_continuation`
  - `decl.rs`: Remove `p.expect(Newline)` since it's handled as trivia
  - `grammar.rs`: Enable `test_parse_multiple_declarations`
  - `expr.rs`: Enable `test_parse_binary_expression_interspersed_with_comments`

  ## Test plan
  - [x] All 51 tests pass
  - [x] Indented expressions correctly wrapped in `Exp_Indented` nodes

  Closes #8